### PR TITLE
Add spec-aware spell refresh

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -302,26 +302,25 @@ function HealIQ:OnPlayerEnteringWorld()
             return
         end
         
-        -- Check if player is a Restoration Druid
-        local _, class = UnitClass("player")
-        if class == "DRUID" then
-            local specIndex = GetSpecialization()
-            if specIndex == 4 then -- Restoration spec
-                self:Print("Restoration Druid detected")
-                self:DebugLog("Restoration Druid detected - enabling addon", "INFO")
-                self.db.enabled = true
-                self:Message("HealIQ enabled for Restoration Druid")
-            else
-                self:Print("Not Restoration spec, addon disabled")
-                self:DebugLog("Not Restoration spec (spec: " .. (specIndex or "unknown") .. ") - disabling addon", "INFO")
-                self.db.enabled = false
-                self:Message("HealIQ disabled (not Restoration spec)")
+        -- Check if player is using a supported specialization
+        if HealIQ.Engine and HealIQ.Engine.IsSupportedSpec and HealIQ.Engine:IsSupportedSpec() then
+            self:Print("Supported specialization detected")
+            self:DebugLog("Supported spec detected - enabling addon", "INFO")
+            self.db.enabled = true
+            if HealIQ.Engine.RefreshSpells then
+                HealIQ.Engine:RefreshSpells()
             end
+            self:Message("HealIQ enabled for supported spec")
         else
-            self:Print("Not a Druid, addon disabled")
-            self:DebugLog("Not a Druid (class: " .. (class or "unknown") .. ") - disabling addon", "INFO")
+            local _, class = UnitClass("player")
+            local specIndex = GetSpecialization()
+            self:Print("Unsupported class/spec, addon disabled")
+            self:DebugLog("Unsupported spec (class: " .. tostring(class) .. ", spec: " .. tostring(specIndex) .. ") - disabling addon", "INFO")
             self.db.enabled = false
-            self:Message("HealIQ disabled (not a Druid)")
+            if HealIQ.Engine and HealIQ.Engine.RefreshSpells then
+                HealIQ.Engine:RefreshSpells()
+            end
+            self:Message("HealIQ disabled (unsupported spec)")
         end
     end)
 end

--- a/HealIQ.toc
+++ b/HealIQ.toc
@@ -1,6 +1,6 @@
 ## Interface: 110107
 ## Title: HealIQ
-## Notes: Smart healing spell suggestion addon for Restoration Druids
+## Notes: Smart healing spell suggestion addon for healers (experimental multi-spec support)
 ## Author: djdefi
 ## Version: 0.1.4
 ## SavedVariables: HealIQDB
@@ -13,6 +13,14 @@ rules/HealingCooldowns.lua
 rules/UtilityRules.lua
 rules/AoERules.lua
 rules/OffensiveRules.lua
+
+# Spec modules
+Specs/HolyPriest.lua
+Specs/DisciplinePriest.lua
+Specs/HolyPaladin.lua
+Specs/RestorationShaman.lua
+Specs/Mistweaver.lua
+Specs/PreservationEvoker.lua
 
 # Core files
 Core.lua

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HealIQ
 
-**HealIQ** is a smart spell suggestion addon for Restoration Druids in World of Warcraft. It helps you prioritize your next healing spell based on current combat context, active HoTs, procs, and cooldowns.
+**HealIQ** is a smart spell suggestion addon for healers in World of Warcraft. Originally built for Restoration Druids, it now includes basic support for multiple healing specializations. The addon helps you prioritize your next healing spell based on current combat context, active HoTs, procs, and cooldowns.
 
 ## 🧠 What It Does
 
@@ -24,7 +24,7 @@
 
 **Note:** HealIQ provides visual suggestions only. Due to Blizzard restrictions, spell casting must be done manually using your normal keybinds or action bars.
 
-> HealIQ is inspired by Hekili, but for healing. Designed with Restoration Druids in mind, support for other healers may be added later.
+> HealIQ is inspired by Hekili, but for healing. It was designed with Restoration Druids in mind, but now includes experimental modules for other healing classes.
 
 ## 📦 Installation
 

--- a/Specs/DisciplinePriest.lua
+++ b/Specs/DisciplinePriest.lua
@@ -1,0 +1,30 @@
+-- HealIQ Specs/DisciplinePriest.lua
+-- Support module for Discipline Priest specialization
+
+local addonName, HealIQ = ...
+
+HealIQ.Specs = HealIQ.Specs or {}
+HealIQ.Specs.DisciplinePriest = {}
+local DisciplinePriest = HealIQ.Specs.DisciplinePriest
+
+-- Placeholder spell list for Discipline Priest
+DisciplinePriest.SPELLS = {
+    -- Example: Power Word: Shield
+    POWER_WORD_SHIELD = {
+        id = 17,
+        name = "Power Word: Shield",
+        icon = "Interface\\Icons\\Spell_Holy_PowerWordShield",
+        priority = 1,
+    }
+}
+
+function DisciplinePriest:IsSupported()
+    local _, class = UnitClass("player")
+    if class ~= "PRIEST" then
+        return false
+    end
+    local specIndex = GetSpecialization()
+    return specIndex == 1 -- Discipline
+end
+
+return DisciplinePriest

--- a/Specs/HolyPaladin.lua
+++ b/Specs/HolyPaladin.lua
@@ -1,0 +1,30 @@
+-- HealIQ Specs/HolyPaladin.lua
+-- Support module for Holy Paladin specialization
+
+local addonName, HealIQ = ...
+
+HealIQ.Specs = HealIQ.Specs or {}
+HealIQ.Specs.HolyPaladin = {}
+local HolyPaladin = HealIQ.Specs.HolyPaladin
+
+-- Placeholder spell list for Holy Paladin
+HolyPaladin.SPELLS = {
+    -- Example: Holy Shock
+    HOLY_SHOCK = {
+        id = 20473,
+        name = "Holy Shock",
+        icon = "Interface\\Icons\\Spell_Holy_SearingLight",
+        priority = 1,
+    }
+}
+
+function HolyPaladin:IsSupported()
+    local _, class = UnitClass("player")
+    if class ~= "PALADIN" then
+        return false
+    end
+    local specIndex = GetSpecialization()
+    return specIndex == 1 -- Holy
+end
+
+return HolyPaladin

--- a/Specs/HolyPriest.lua
+++ b/Specs/HolyPriest.lua
@@ -1,0 +1,31 @@
+-- HealIQ Specs/HolyPriest.lua
+-- Support module for Holy Priest specialization
+
+local addonName, HealIQ = ...
+
+HealIQ.Specs = HealIQ.Specs or {}
+HealIQ.Specs.HolyPriest = {}
+local HolyPriest = HealIQ.Specs.HolyPriest
+
+-- Placeholder spell list for Holy Priest
+-- Actual priority logic and spells need to be implemented
+HolyPriest.SPELLS = {
+    -- Example: Holy Word: Serenity
+    HOLY_WORD_SERENITY = {
+        id = 2050,
+        name = "Holy Word: Serenity",
+        icon = "Interface\\Icons\\Spell_Holy_HolyBolt",
+        priority = 1,
+    }
+}
+
+function HolyPriest:IsSupported()
+    local _, class = UnitClass("player")
+    if class ~= "PRIEST" then
+        return false
+    end
+    local specIndex = GetSpecialization()
+    return specIndex == 2 -- Holy
+end
+
+return HolyPriest

--- a/Specs/Mistweaver.lua
+++ b/Specs/Mistweaver.lua
@@ -1,0 +1,30 @@
+-- HealIQ Specs/Mistweaver.lua
+-- Support module for Mistweaver Monk specialization
+
+local addonName, HealIQ = ...
+
+HealIQ.Specs = HealIQ.Specs or {}
+HealIQ.Specs.Mistweaver = {}
+local Mistweaver = HealIQ.Specs.Mistweaver
+
+-- Placeholder spell list for Mistweaver Monk
+Mistweaver.SPELLS = {
+    -- Example: Vivify
+    VIVIFY = {
+        id = 116670,
+        name = "Vivify",
+        icon = "Interface\\Icons\\spell_monk_vivify",
+        priority = 1,
+    }
+}
+
+function Mistweaver:IsSupported()
+    local _, class = UnitClass("player")
+    if class ~= "MONK" then
+        return false
+    end
+    local specIndex = GetSpecialization()
+    return specIndex == 2 -- Mistweaver
+end
+
+return Mistweaver

--- a/Specs/PreservationEvoker.lua
+++ b/Specs/PreservationEvoker.lua
@@ -1,0 +1,30 @@
+-- HealIQ Specs/PreservationEvoker.lua
+-- Support module for Preservation Evoker specialization
+
+local addonName, HealIQ = ...
+
+HealIQ.Specs = HealIQ.Specs or {}
+HealIQ.Specs.PreservationEvoker = {}
+local PreservationEvoker = HealIQ.Specs.PreservationEvoker
+
+-- Placeholder spell list for Preservation Evoker
+PreservationEvoker.SPELLS = {
+    -- Example: Dream Breath
+    DREAM_BREATH = {
+        id = 382614,
+        name = "Dream Breath",
+        icon = "Interface\\Icons\\Ability_Evoker_DreamBreath",
+        priority = 1,
+    }
+}
+
+function PreservationEvoker:IsSupported()
+    local _, class = UnitClass("player")
+    if class ~= "EVOKER" then
+        return false
+    end
+    local specIndex = GetSpecialization()
+    return specIndex == 2 -- Preservation
+end
+
+return PreservationEvoker

--- a/Specs/RestorationShaman.lua
+++ b/Specs/RestorationShaman.lua
@@ -1,0 +1,30 @@
+-- HealIQ Specs/RestorationShaman.lua
+-- Support module for Restoration Shaman specialization
+
+local addonName, HealIQ = ...
+
+HealIQ.Specs = HealIQ.Specs or {}
+HealIQ.Specs.RestorationShaman = {}
+local RestorationShaman = HealIQ.Specs.RestorationShaman
+
+-- Placeholder spell list for Restoration Shaman
+RestorationShaman.SPELLS = {
+    -- Example: Riptide
+    RIPTIDE = {
+        id = 61295,
+        name = "Riptide",
+        icon = "Interface\\Icons\\spell_nature_riptide",
+        priority = 1,
+    }
+}
+
+function RestorationShaman:IsSupported()
+    local _, class = UnitClass("player")
+    if class ~= "SHAMAN" then
+        return false
+    end
+    local specIndex = GetSpecialization()
+    return specIndex == 3 -- Restoration
+end
+
+return RestorationShaman


### PR DESCRIPTION
## Summary
- add `Engine:GetActiveSpecModule` and `Engine:RefreshSpells`
- refresh spell table when entering world
- update addon notes in `.toc` and ensure newline at EOF

## Testing
- `lua test_runner.lua`

------
https://chatgpt.com/codex/tasks/task_e_68814705d9d08322b4e31f96df54cea6