### PR TITLE
Add spec module registration

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -281,6 +281,9 @@ function HealIQ:OnEvent(event, ...)
             self:OnPlayerLogin()
         elseif event == "PLAYER_ENTERING_WORLD" then
             self:OnPlayerEnteringWorld()
+        elseif event == "PLAYER_SPECIALIZATION_CHANGED" then
+            local unit = args[1]
+            self:OnSpecializationChanged(unit)
         end
     end)
 end
@@ -302,26 +305,56 @@ function HealIQ:OnPlayerEnteringWorld()
             return
         end
         
-        -- Check if player is a Restoration Druid
-        local _, class = UnitClass("player")
-        if class == "DRUID" then
-            local specIndex = GetSpecialization()
-            if specIndex == 4 then -- Restoration spec
-                self:Print("Restoration Druid detected")
-                self:DebugLog("Restoration Druid detected - enabling addon", "INFO")
-                self.db.enabled = true
-                self:Message("HealIQ enabled for Restoration Druid")
-            else
-                self:Print("Not Restoration spec, addon disabled")
-                self:DebugLog("Not Restoration spec (spec: " .. (specIndex or "unknown") .. ") - disabling addon", "INFO")
-                self.db.enabled = false
-                self:Message("HealIQ disabled (not Restoration spec)")
+        -- Check if player is using a supported specialization
+        if HealIQ.Engine and HealIQ.Engine.IsSupportedSpec and HealIQ.Engine:IsSupportedSpec() then
+            self:Print("Supported specialization detected")
+            self:DebugLog("Supported spec detected - enabling addon", "INFO")
+            self.db.enabled = true
+            if HealIQ.Engine.RefreshSpells then
+                HealIQ.Engine:RefreshSpells()
             end
+            self:Message("HealIQ enabled for supported spec")
         else
-            self:Print("Not a Druid, addon disabled")
-            self:DebugLog("Not a Druid (class: " .. (class or "unknown") .. ") - disabling addon", "INFO")
+            local _, class = UnitClass("player")
+            local specIndex = GetSpecialization()
+            self:Print("Unsupported class/spec, addon disabled")
+            self:DebugLog("Unsupported spec (class: " .. tostring(class) .. ", spec: " .. tostring(specIndex) .. ") - disabling addon", "INFO")
             self.db.enabled = false
-            self:Message("HealIQ disabled (not a Druid)")
+            if HealIQ.Engine and HealIQ.Engine.RefreshSpells then
+                HealIQ.Engine:RefreshSpells()
+            end
+            self:Message("HealIQ disabled (unsupported spec)")
+        end
+    end)
+end
+
+function HealIQ:OnSpecializationChanged(unit)
+    self:SafeCall(function()
+        if unit ~= "player" then
+            return
+        end
+
+        local prevEnabled = self.db and self.db.enabled
+
+        local supported = HealIQ.Engine and HealIQ.Engine.IsSupportedSpec and HealIQ.Engine:IsSupportedSpec()
+        if supported then
+            self.db.enabled = true
+            self:DebugLog("Specialization changed - supported spec", "INFO")
+        else
+            self.db.enabled = false
+            self:DebugLog("Specialization changed - unsupported spec", "INFO")
+        end
+
+        if HealIQ.Engine and HealIQ.Engine.RefreshSpells then
+            HealIQ.Engine:RefreshSpells()
+        end
+
+        if prevEnabled ~= self.db.enabled then
+            if self.db.enabled then
+                self:Message("HealIQ enabled for supported spec")
+            else
+                self:Message("HealIQ disabled (unsupported spec)")
+            end
         end
     end)
 end
@@ -331,6 +364,7 @@ local eventFrame = CreateFrame("Frame")
 eventFrame:RegisterEvent("ADDON_LOADED")
 eventFrame:RegisterEvent("PLAYER_LOGIN")
 eventFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
+eventFrame:RegisterEvent("PLAYER_SPECIALIZATION_CHANGED")
 eventFrame:SetScript("OnEvent", function(self, event, ...)
     HealIQ:OnEvent(event, ...)
 end)

--- a/Engine.lua
+++ b/Engine.lua
@@ -6,6 +6,27 @@ local addonName, HealIQ = ...
 HealIQ.Engine = {}
 local Engine = HealIQ.Engine
 
+-- Supported class specializations
+Engine.supportedSpecs = {
+    DRUID = {4},           -- Restoration
+    PRIEST = {1, 2},       -- Discipline, Holy
+    PALADIN = {1},         -- Holy
+    SHAMAN = {3},          -- Restoration
+    MONK = {2},            -- Mistweaver
+    EVOKER = {2},          -- Preservation
+}
+
+-- Table to hold registered spec modules
+Engine.specModules = {}
+
+-- Register a specialization support module
+function Engine:RegisterSpec(name, module)
+    if type(name) ~= "string" or type(module) ~= "table" then
+        return
+    end
+    self.specModules[name] = module
+end
+
 -- Targeting types and their associated icons
 -- Icon path constants
 local ICON_SELF = "Interface\\Icons\\Ability_Warrior_BattleShout"
@@ -62,135 +83,7 @@ local TARGET_TYPES = {
 
 -- Spell information for suggestions with targeting recommendations
 -- Updated priorities based on Wowhead Restoration Druid guide
-local SPELLS = {
-    -- Emergency/Major Cooldowns (Highest Priority)
-    TRANQUILITY = {
-        id = 740,
-        name = "Tranquility",
-        icon = "Interface\\Icons\\Spell_Nature_Tranquility",
-        priority = 1,
-        targets = {TARGET_TYPES.SELF}, -- Channel on self, affects all nearby allies
-        targetingDescription = "Channel while positioned near injured allies"
-    },
-    INCARNATION_TREE = {
-        id = 33891,
-        name = "Incarnation",
-        icon = "Interface\\Icons\\Spell_Druid_Incarnation",
-        priority = 2,
-        targets = {TARGET_TYPES.SELF}, -- Self-buff
-        targetingDescription = "Activate when group healing is needed"
-    },
-    NATURES_SWIFTNESS = {
-        id = 132158,
-        name = "Nature's Swiftness",
-        icon = "Interface\\Icons\\Spell_Nature_RavenForm",
-        priority = 3,
-        targets = {TARGET_TYPES.SELF}, -- Self-buff for next spell
-        targetingDescription = "Use before emergency heal cast"
-    },
-    
-    -- Core Maintenance (High Priority - keep these active)
-    EFFLORESCENCE = {
-        id = 145205,
-        name = "Efflorescence",
-        icon = "Interface\\Icons\\Ability_Druid_Efflorescence",
-        priority = 4, -- Higher priority per guide: "keep active as frequently as possible"
-        targets = {TARGET_TYPES.GROUND_TARGET}, -- Ground-targeted spell
-        targetingDescription = "Place where group will be standing"
-    },
-    LIFEBLOOM = {
-        id = 33763,
-        name = "Lifebloom",
-        icon = "Interface\\Icons\\INV_Misc_Herb_Felblossom",
-        priority = 5, -- Higher priority per guide: "keep active on tank"
-        targets = {TARGET_TYPES.TANK, TARGET_TYPES.FOCUS, TARGET_TYPES.CURRENT_TARGET}, -- Tank maintenance
-        targetingDescription = "Keep active on main tank or focus target"
-    },
-    
-    -- Proc-based spells (High Priority when available)
-    REGROWTH = {
-        id = 8936,
-        name = "Regrowth",
-        icon = "Interface\\Icons\\Spell_Nature_ResistNature",
-        priority = 6, -- Higher priority when used with Clearcasting
-        targets = {TARGET_TYPES.LOWEST_HEALTH, TARGET_TYPES.CURRENT_TARGET, TARGET_TYPES.TANK}, -- Direct heal
-        targetingDescription = "Target needs immediate healing"
-    },
-    
-    -- AoE Healing Combo
-    SWIFTMEND = {
-        id = 18562,
-        name = "Swiftmend",
-        icon = "Interface\\Icons\\INV_Relics_IdolofRejuvenation",
-        priority = 7, -- Higher priority as setup for Wild Growth
-        targets = {TARGET_TYPES.CURRENT_TARGET, TARGET_TYPES.LOWEST_HEALTH}, -- Target with HoTs
-        targetingDescription = "Target must have Rejuvenation or Regrowth"
-    },
-    WILD_GROWTH = {
-        id = 48438,
-        name = "Wild Growth",
-        icon = "Interface\\Icons\\Ability_Druid_WildGrowth",
-        priority = 8, -- Often paired with Swiftmend
-        targets = {TARGET_TYPES.PARTY_MEMBER, TARGET_TYPES.CURRENT_TARGET}, -- Smart heal around target
-        targetingDescription = "Target near damaged party members"
-    },
-    
-    -- Cooldown Management
-    GROVE_GUARDIANS = {
-        id = 102693,
-        name = "Grove Guardians",
-        icon = "Interface\\Icons\\Spell_Druid_Treant",
-        priority = 9,
-        targets = {TARGET_TYPES.SELF}, -- Self-activated with charges
-        targetingDescription = "Pool charges for big cooldowns"
-    },
-    FLOURISH = {
-        id = 197721,
-        name = "Flourish",
-        icon = "Interface\\Icons\\Spell_Druid_WildGrowth",
-        priority = 10,
-        targets = {TARGET_TYPES.SELF}, -- Affects all your HoTs
-        targetingDescription = "Use when multiple HoTs are active"
-    },
-    
-    -- Defensive/Utility
-    IRONBARK = {
-        id = 102342,
-        name = "Ironbark",
-        icon = "Interface\\Icons\\Spell_Druid_IronBark",
-        priority = 11,
-        targets = {TARGET_TYPES.TANK, TARGET_TYPES.CURRENT_TARGET, TARGET_TYPES.FOCUS}, -- Damage reduction
-        targetingDescription = "Prioritize tanks or targets taking heavy damage"
-    },
-    BARKSKIN = {
-        id = 22812,
-        name = "Barkskin",
-        icon = "Interface\\Icons\\Spell_Nature_StoneSkinTotem",
-        priority = 12,
-        targets = {TARGET_TYPES.SELF}, -- Self-defensive
-        targetingDescription = "Use when taking damage"
-    },
-    
-    -- Ramping HoTs (Lower priority during maintenance, higher during damage phases)
-    REJUVENATION = {
-        id = 774,
-        name = "Rejuvenation",
-        icon = "Interface\\Icons\\Spell_Nature_Rejuvenation",
-        priority = 13,
-        targets = {TARGET_TYPES.PARTY_MEMBER, TARGET_TYPES.CURRENT_TARGET, TARGET_TYPES.TANK}, -- Basic HoT
-        targetingDescription = "Apply to targets without HoT coverage"
-    },
-    
-    -- Filler/Mana Management
-    WRATH = {
-        id = 5176,
-        name = "Wrath",
-        icon = "Interface\\Icons\\Spell_Nature_AbolishMagic",
-        priority = 14,
-        targets = {TARGET_TYPES.CURRENT_TARGET}, -- Enemy target
-        targetingDescription = "Use on enemies during downtime for mana restoration"
-    },
-}
+local SPELLS = HealIQ.Specs and HealIQ.Specs.RestorationDruid and HealIQ.Specs.RestorationDruid.SPELLS or {}
 
 -- Current suggestion state
 local currentSuggestion = nil
@@ -249,20 +142,61 @@ function Engine:OnUpdate(elapsed)
         local suggestion = self:EvaluateRules()
         local queue = self:EvaluateRulesQueue()
         
+
         self:SetSuggestion(suggestion)
         self:SetQueue(queue)
     end)
 end
 
-function Engine:ShouldSuggest()
-    -- Only suggest if player is a Restoration Druid
+function Engine:IsSupportedSpec()
     local _, class = UnitClass("player")
-    if class ~= "DRUID" then
+    local specIndex = GetSpecialization()
+    local specs = self.supportedSpecs[class]
+    if not specs then
         return false
     end
-    
-    local specIndex = GetSpecialization()
-    if specIndex ~= 4 then -- Not Restoration
+    for _, idx in ipairs(specs) do
+        if idx == specIndex then
+            return true
+        end
+    end
+    return false
+end
+
+function Engine:GetActiveSpecModule()
+    for _, mod in pairs(self.specModules) do
+        if type(mod.IsSupported) == "function" and mod:IsSupported() then
+            return mod
+        end
+    end
+    if HealIQ.Specs then
+        for _, mod in pairs(HealIQ.Specs) do
+            if type(mod.IsSupported) == "function" and mod:IsSupported() then
+                return mod
+            end
+        end
+    end
+    return nil
+end
+
+function Engine:RefreshSpells()
+    local mod = self:GetActiveSpecModule()
+    if mod then
+        if type(mod.GetSpells) == "function" then
+            self.SPELLS = mod:GetSpells()
+        elseif mod.SPELLS then
+            self.SPELLS = mod.SPELLS
+        else
+            self.SPELLS = self.defaultSpells
+        end
+    else
+        self.SPELLS = self.defaultSpells
+    end
+end
+
+function Engine:ShouldSuggest()
+    -- Only suggest if player is using a supported spec
+    if not self:IsSupportedSpec() then
         return false
     end
     
@@ -1116,4 +1050,7 @@ end
 
 HealIQ.Engine = Engine
 HealIQ.Engine.TARGET_TYPES = TARGET_TYPES
+Engine.defaultSpells = SPELLS
+Engine.SPELLS = SPELLS
 HealIQ.Engine.SPELLS = SPELLS
+

--- a/HealIQ.toc
+++ b/HealIQ.toc
@@ -1,6 +1,6 @@
 ## Interface: 110107
 ## Title: HealIQ
-## Notes: Smart healing spell suggestion addon for Restoration Druids
+## Notes: Smart healing spell suggestion addon for healers (experimental multi-spec support)
 ## Author: djdefi
 ## Version: 0.1.4
 ## SavedVariables: HealIQDB
@@ -13,6 +13,15 @@ rules/HealingCooldowns.lua
 rules/UtilityRules.lua
 rules/AoERules.lua
 rules/OffensiveRules.lua
+
+# Spec modules
+Specs/HolyPriest.lua
+Specs/DisciplinePriest.lua
+Specs/HolyPaladin.lua
+Specs/RestorationDruid.lua
+Specs/RestorationShaman.lua
+Specs/Mistweaver.lua
+Specs/PreservationEvoker.lua
 
 # Core files
 Core.lua

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HealIQ
 
-**HealIQ** is a smart spell suggestion addon for Restoration Druids in World of Warcraft. It helps you prioritize your next healing spell based on current combat context, active HoTs, procs, and cooldowns.
+**HealIQ** is a smart spell suggestion addon for healers in World of Warcraft. Originally built for Restoration Druids, it now includes basic support for multiple healing specializations through modular spec files. The addon helps you prioritize your next healing spell based on current combat context, active HoTs, procs, and cooldowns.
 
 ## 🧠 What It Does
 
@@ -11,6 +11,8 @@
 - Alerts for cooldown-based healing (e.g. Wild Growth, Tranquility)
 - Supports movement and configuration of suggestion UI
 - Shows upcoming suggestions in a queue display
+- Automatically detects specialization changes and loads the appropriate module
+- Specialization modules register themselves with the engine for seamless multi-spec support
 - Provides extensive strategy customization options
 
 **Enhanced Strategy Features:**
@@ -24,7 +26,7 @@
 
 **Note:** HealIQ provides visual suggestions only. Due to Blizzard restrictions, spell casting must be done manually using your normal keybinds or action bars.
 
-> HealIQ is inspired by Hekili, but for healing. Designed with Restoration Druids in mind, support for other healers may be added later.
+> HealIQ is inspired by Hekili, but for healing. It was designed with Restoration Druids in mind, but now includes experimental modules for other healing classes.
 
 ## 📦 Installation
 
@@ -67,6 +69,11 @@ Healing doesn’t follow a strict rotation, but there are patterns of optimal de
 ## 🛠 For Developers
 
 This addon is written in Lua using the WoW AddOn API.
+
+To add support for another healing specialization, create a file in `Specs/` that
+defines your spell table and an `IsSupported` method. At the end of the file,
+register the module with `HealIQ.Engine:RegisterSpec("YourSpecName", module)` so
+the core engine can load it automatically when the player swaps specs.
 
 Contributions and suggestions welcome via [Issues](https://github.com/djdefi/healiq/issues) and PRs.
 

--- a/Specs/DisciplinePriest.lua
+++ b/Specs/DisciplinePriest.lua
@@ -1,0 +1,34 @@
+-- HealIQ Specs/DisciplinePriest.lua
+-- Support module for Discipline Priest specialization
+
+local addonName, HealIQ = ...
+
+HealIQ.Specs = HealIQ.Specs or {}
+HealIQ.Specs.DisciplinePriest = {}
+local DisciplinePriest = HealIQ.Specs.DisciplinePriest
+
+-- Placeholder spell list for Discipline Priest
+DisciplinePriest.SPELLS = {
+    -- Example: Power Word: Shield
+    POWER_WORD_SHIELD = {
+        id = 17,
+        name = "Power Word: Shield",
+        icon = "Interface\\Icons\\Spell_Holy_PowerWordShield",
+        priority = 1,
+    }
+}
+
+function DisciplinePriest:IsSupported()
+    local _, class = UnitClass("player")
+    if class ~= "PRIEST" then
+        return false
+    end
+    local specIndex = GetSpecialization()
+    return specIndex == 1 -- Discipline
+end
+
+if HealIQ and HealIQ.Engine and HealIQ.Engine.RegisterSpec then
+    HealIQ.Engine:RegisterSpec("DisciplinePriest", DisciplinePriest)
+end
+
+return DisciplinePriest

--- a/Specs/HolyPaladin.lua
+++ b/Specs/HolyPaladin.lua
@@ -1,0 +1,34 @@
+-- HealIQ Specs/HolyPaladin.lua
+-- Support module for Holy Paladin specialization
+
+local addonName, HealIQ = ...
+
+HealIQ.Specs = HealIQ.Specs or {}
+HealIQ.Specs.HolyPaladin = {}
+local HolyPaladin = HealIQ.Specs.HolyPaladin
+
+-- Placeholder spell list for Holy Paladin
+HolyPaladin.SPELLS = {
+    -- Example: Holy Shock
+    HOLY_SHOCK = {
+        id = 20473,
+        name = "Holy Shock",
+        icon = "Interface\\Icons\\Spell_Holy_SearingLight",
+        priority = 1,
+    }
+}
+
+function HolyPaladin:IsSupported()
+    local _, class = UnitClass("player")
+    if class ~= "PALADIN" then
+        return false
+    end
+    local specIndex = GetSpecialization()
+    return specIndex == 1 -- Holy
+end
+
+if HealIQ and HealIQ.Engine and HealIQ.Engine.RegisterSpec then
+    HealIQ.Engine:RegisterSpec("HolyPaladin", HolyPaladin)
+end
+
+return HolyPaladin

--- a/Specs/HolyPriest.lua
+++ b/Specs/HolyPriest.lua
@@ -1,0 +1,35 @@
+-- HealIQ Specs/HolyPriest.lua
+-- Support module for Holy Priest specialization
+
+local addonName, HealIQ = ...
+
+HealIQ.Specs = HealIQ.Specs or {}
+HealIQ.Specs.HolyPriest = {}
+local HolyPriest = HealIQ.Specs.HolyPriest
+
+-- Placeholder spell list for Holy Priest
+-- Actual priority logic and spells need to be implemented
+HolyPriest.SPELLS = {
+    -- Example: Holy Word: Serenity
+    HOLY_WORD_SERENITY = {
+        id = 2050,
+        name = "Holy Word: Serenity",
+        icon = "Interface\\Icons\\Spell_Holy_HolyBolt",
+        priority = 1,
+    }
+}
+
+function HolyPriest:IsSupported()
+    local _, class = UnitClass("player")
+    if class ~= "PRIEST" then
+        return false
+    end
+    local specIndex = GetSpecialization()
+    return specIndex == 2 -- Holy
+end
+
+if HealIQ and HealIQ.Engine and HealIQ.Engine.RegisterSpec then
+    HealIQ.Engine:RegisterSpec("HolyPriest", HolyPriest)
+end
+
+return HolyPriest

--- a/Specs/Mistweaver.lua
+++ b/Specs/Mistweaver.lua
@@ -1,0 +1,34 @@
+-- HealIQ Specs/Mistweaver.lua
+-- Support module for Mistweaver Monk specialization
+
+local addonName, HealIQ = ...
+
+HealIQ.Specs = HealIQ.Specs or {}
+HealIQ.Specs.Mistweaver = {}
+local Mistweaver = HealIQ.Specs.Mistweaver
+
+-- Placeholder spell list for Mistweaver Monk
+Mistweaver.SPELLS = {
+    -- Example: Vivify
+    VIVIFY = {
+        id = 116670,
+        name = "Vivify",
+        icon = "Interface\\Icons\\spell_monk_vivify",
+        priority = 1,
+    }
+}
+
+function Mistweaver:IsSupported()
+    local _, class = UnitClass("player")
+    if class ~= "MONK" then
+        return false
+    end
+    local specIndex = GetSpecialization()
+    return specIndex == 2 -- Mistweaver
+end
+
+if HealIQ and HealIQ.Engine and HealIQ.Engine.RegisterSpec then
+    HealIQ.Engine:RegisterSpec("Mistweaver", Mistweaver)
+end
+
+return Mistweaver

--- a/Specs/PreservationEvoker.lua
+++ b/Specs/PreservationEvoker.lua
@@ -1,0 +1,34 @@
+-- HealIQ Specs/PreservationEvoker.lua
+-- Support module for Preservation Evoker specialization
+
+local addonName, HealIQ = ...
+
+HealIQ.Specs = HealIQ.Specs or {}
+HealIQ.Specs.PreservationEvoker = {}
+local PreservationEvoker = HealIQ.Specs.PreservationEvoker
+
+-- Placeholder spell list for Preservation Evoker
+PreservationEvoker.SPELLS = {
+    -- Example: Dream Breath
+    DREAM_BREATH = {
+        id = 382614,
+        name = "Dream Breath",
+        icon = "Interface\\Icons\\Ability_Evoker_DreamBreath",
+        priority = 1,
+    }
+}
+
+function PreservationEvoker:IsSupported()
+    local _, class = UnitClass("player")
+    if class ~= "EVOKER" then
+        return false
+    end
+    local specIndex = GetSpecialization()
+    return specIndex == 2 -- Preservation
+end
+
+if HealIQ and HealIQ.Engine and HealIQ.Engine.RegisterSpec then
+    HealIQ.Engine:RegisterSpec("PreservationEvoker", PreservationEvoker)
+end
+
+return PreservationEvoker

--- a/Specs/RestorationDruid.lua
+++ b/Specs/RestorationDruid.lua
@@ -1,0 +1,164 @@
+-- HealIQ Specs/RestorationDruid.lua
+-- Default spell definitions for Restoration Druid specialization
+
+local addonName, HealIQ = ...
+
+HealIQ.Specs = HealIQ.Specs or {}
+HealIQ.Specs.RestorationDruid = {}
+local RestorationDruid = HealIQ.Specs.RestorationDruid
+
+-- Full spell table moved from Engine.lua
+local function CreateSpells()
+    local TT = HealIQ.Engine and HealIQ.Engine.TARGET_TYPES or {}
+    return {
+        -- Emergency/Major Cooldowns (Highest Priority)
+    TRANQUILITY = {
+        id = 740,
+        name = "Tranquility",
+        icon = "Interface\\Icons\\Spell_Nature_Tranquility",
+        priority = 1,
+        targets = {TT.SELF}, -- Channel on self, affects all nearby allies
+        targetingDescription = "Channel while positioned near injured allies"
+    },
+    INCARNATION_TREE = {
+        id = 33891,
+        name = "Incarnation",
+        icon = "Interface\\Icons\\Spell_Druid_Incarnation",
+        priority = 2,
+        targets = {TT.SELF}, -- Self-buff
+        targetingDescription = "Activate when group healing is needed"
+    },
+    NATURES_SWIFTNESS = {
+        id = 132158,
+        name = "Nature's Swiftness",
+        icon = "Interface\\Icons\\Spell_Nature_RavenForm",
+        priority = 3,
+        targets = {TT.SELF}, -- Self-buff for next spell
+        targetingDescription = "Use before emergency heal cast"
+    },
+    
+    -- Core Maintenance (High Priority - keep these active)
+    EFFLORESCENCE = {
+        id = 145205,
+        name = "Efflorescence",
+        icon = "Interface\\Icons\\Ability_Druid_Efflorescence",
+        priority = 4, -- Higher priority per guide: "keep active as frequently as possible"
+        targets = {TT.GROUND_TARGET}, -- Ground-targeted spell
+        targetingDescription = "Place where group will be standing"
+    },
+    LIFEBLOOM = {
+        id = 33763,
+        name = "Lifebloom",
+        icon = "Interface\\Icons\\INV_Misc_Herb_Felblossom",
+        priority = 5, -- Higher priority per guide: "keep active on tank"
+        targets = {TT.TANK, TT.FOCUS, TT.CURRENT_TARGET}, -- Tank maintenance
+        targetingDescription = "Keep active on main tank or focus target"
+    },
+    
+    -- Proc-based spells (High Priority when available)
+    REGROWTH = {
+        id = 8936,
+        name = "Regrowth",
+        icon = "Interface\\Icons\\Spell_Nature_ResistNature",
+        priority = 6, -- Higher priority when used with Clearcasting
+        targets = {TT.LOWEST_HEALTH, TT.CURRENT_TARGET, TT.TANK}, -- Direct heal
+        targetingDescription = "Target needs immediate healing"
+    },
+    
+    -- AoE Healing Combo
+    SWIFTMEND = {
+        id = 18562,
+        name = "Swiftmend",
+        icon = "Interface\\Icons\\INV_Relics_IdolofRejuvenation",
+        priority = 7, -- Higher priority as setup for Wild Growth
+        targets = {TT.CURRENT_TARGET, TT.LOWEST_HEALTH}, -- Target with HoTs
+        targetingDescription = "Target must have Rejuvenation or Regrowth"
+    },
+    WILD_GROWTH = {
+        id = 48438,
+        name = "Wild Growth",
+        icon = "Interface\\Icons\\Ability_Druid_WildGrowth",
+        priority = 8, -- Often paired with Swiftmend
+        targets = {TT.PARTY_MEMBER, TT.CURRENT_TARGET}, -- Smart heal around target
+        targetingDescription = "Target near damaged party members"
+    },
+    
+    -- Cooldown Management
+    GROVE_GUARDIANS = {
+        id = 102693,
+        name = "Grove Guardians",
+        icon = "Interface\\Icons\\Spell_Druid_Treant",
+        priority = 9,
+        targets = {TT.SELF}, -- Self-activated with charges
+        targetingDescription = "Pool charges for big cooldowns"
+    },
+    FLOURISH = {
+        id = 197721,
+        name = "Flourish",
+        icon = "Interface\\Icons\\Spell_Druid_WildGrowth",
+        priority = 10,
+        targets = {TT.SELF}, -- Affects all your HoTs
+        targetingDescription = "Use when multiple HoTs are active"
+    },
+    
+    -- Defensive/Utility
+    IRONBARK = {
+        id = 102342,
+        name = "Ironbark",
+        icon = "Interface\\Icons\\Spell_Druid_IronBark",
+        priority = 11,
+        targets = {TT.TANK, TT.CURRENT_TARGET, TT.FOCUS}, -- Damage reduction
+        targetingDescription = "Prioritize tanks or targets taking heavy damage"
+    },
+    BARKSKIN = {
+        id = 22812,
+        name = "Barkskin",
+        icon = "Interface\\Icons\\Spell_Nature_StoneSkinTotem",
+        priority = 12,
+        targets = {TT.SELF}, -- Self-defensive
+        targetingDescription = "Use when taking damage"
+    },
+    
+    -- Ramping HoTs (Lower priority during maintenance, higher during damage phases)
+    REJUVENATION = {
+        id = 774,
+        name = "Rejuvenation",
+        icon = "Interface\\Icons\\Spell_Nature_Rejuvenation",
+        priority = 13,
+        targets = {TT.PARTY_MEMBER, TT.CURRENT_TARGET, TT.TANK}, -- Basic HoT
+        targetingDescription = "Apply to targets without HoT coverage"
+    },
+    
+    -- Filler/Mana Management
+    WRATH = {
+        id = 5176,
+        name = "Wrath",
+        icon = "Interface\\Icons\\Spell_Nature_AbolishMagic",
+        priority = 14,
+        targets = {TT.CURRENT_TARGET}, -- Enemy target
+        targetingDescription = "Use on enemies during downtime for mana restoration"
+    },
+    }
+end
+
+function RestorationDruid:GetSpells()
+    if not self.SPELLS then
+        self.SPELLS = CreateSpells()
+    end
+    return self.SPELLS
+end
+
+function RestorationDruid:IsSupported()
+    local _, class = UnitClass("player")
+    if class ~= "DRUID" then
+        return false
+    end
+    local specIndex = GetSpecialization()
+    return specIndex == 4 -- Restoration
+end
+
+if HealIQ and HealIQ.Engine and HealIQ.Engine.RegisterSpec then
+    HealIQ.Engine:RegisterSpec("RestorationDruid", RestorationDruid)
+end
+
+return RestorationDruid

--- a/Specs/RestorationShaman.lua
+++ b/Specs/RestorationShaman.lua
@@ -1,0 +1,34 @@
+-- HealIQ Specs/RestorationShaman.lua
+-- Support module for Restoration Shaman specialization
+
+local addonName, HealIQ = ...
+
+HealIQ.Specs = HealIQ.Specs or {}
+HealIQ.Specs.RestorationShaman = {}
+local RestorationShaman = HealIQ.Specs.RestorationShaman
+
+-- Placeholder spell list for Restoration Shaman
+RestorationShaman.SPELLS = {
+    -- Example: Riptide
+    RIPTIDE = {
+        id = 61295,
+        name = "Riptide",
+        icon = "Interface\\Icons\\spell_nature_riptide",
+        priority = 1,
+    }
+}
+
+function RestorationShaman:IsSupported()
+    local _, class = UnitClass("player")
+    if class ~= "SHAMAN" then
+        return false
+    end
+    local specIndex = GetSpecialization()
+    return specIndex == 3 -- Restoration
+end
+
+if HealIQ and HealIQ.Engine and HealIQ.Engine.RegisterSpec then
+    HealIQ.Engine:RegisterSpec("RestorationShaman", RestorationShaman)
+end
+
+return RestorationShaman


### PR DESCRIPTION
## Summary
- allow specialization modules to register with the engine
- engine loads modules from registration table before scanning `HealIQ.Specs`
- specs now register themselves with `HealIQ.Engine:RegisterSpec`
- document how to add new modules in README
- **fix module registration order** so registration actually occurs

## Testing
- `lua test_runner.lua`

------
https://chatgpt.com/codex/tasks/task_e_68814705d9d08322b4e31f96df54cea6